### PR TITLE
Cleanup FloatingIPs before routers

### DIFF
--- a/terraform/scripts/cleanup.py
+++ b/terraform/scripts/cleanup.py
@@ -181,8 +181,8 @@ def main():
     cleanup_subnets(conn, PREFIX)
     cleanup_networks(conn, PREFIX)
     cleanup_security_groups(conn, PREFIX)
-    cleanup_routers(conn, PREFIX)
     cleanup_floating_ips(conn, PREFIX)
+    cleanup_routers(conn, PREFIX)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
On OpenTelekomCloud EIPs needs to be cleaned up before routers, otherwise router cleanup will fail.