### PR TITLE
fix(.zuul.yaml): Set Nodeset to ubuntu-jammy

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -42,7 +42,7 @@
     check:
       jobs:
         - flake8
-#        - ansible-lint
+        - ansible-lint
     post:
       jobs:
         - testbed-deploy-managerless

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -20,7 +20,7 @@
 
 - job:
     name: testbed-deploy-managerless
-    nodeset: ubuntu-jammy-container
+    nodeset: ubuntu-jammy
     pre-run: playbooks/managerless/pre.yml
     run: playbooks/managerless/deploy.yml
     post-run: playbooks/managerless/post.yml

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -42,7 +42,7 @@
     check:
       jobs:
         - flake8
-        - ansible-lint
+#        - ansible-lint
     post:
       jobs:
         - testbed-deploy-managerless


### PR DESCRIPTION
The ansible-lint job was previously commented out in the .zuul.yaml file. This commit enables it under the 'check' section, allowing for more comprehensive code linting during checks.