### PR TITLE
 feat(.zuul.yaml): Disable ansible-lint in periodic jobs

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -48,7 +48,7 @@
         - testbed-deploy-managerless
     periodic-hourly-otc:
       jobs:
-        - ansible-lint
+        # - ansible-lint
         - flake8
 #        - testbed-deploy-managerless
 #        - python-black


### PR DESCRIPTION
The ansible-lint job has been commented out from the periodic-hourly-otc section. This means it will no longer run as part of the hourly checks. Other jobs like flake8 remain unaffected.